### PR TITLE
Multi-target-platform build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
   <properties>
     <tycho-version>0.13.0</tycho-version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <platform-version-name>indigo</platform-version-name>
+    <platform-version-name>helios</platform-version-name>
     <eclipse-site>http://download.eclipse.org/releases/${platform-version-name}</eclipse-site>
   </properties>
 


### PR DESCRIPTION
Target platform can be choosen using one of the Maven profiles (e.g. `-Pplatform-indigo`) or setting the property `platform-version-name` (e.g. to `indigo`).

Default platform remains helios for now.
