### PR TITLE
avoid umlauts in source files

### DIFF
--- a/org.projectusus.core/src/org/projectusus/core/filerelations/model/ClassDescriptor.java
+++ b/org.projectusus.core/src/org/projectusus/core/filerelations/model/ClassDescriptor.java
@@ -105,7 +105,7 @@ public class ClassDescriptor {
     }
 
     public String qualifiedClassName() {
-        return key.getPackagename() + "." + key.getClassname(); //$NON-NLS-1$ 
+        return key.getPackagename() + "." + key.getClassname(); //$NON-NLS-1$
     }
 
     private void clearOwnAndParentsTransitiveChildrenCache() {
@@ -199,7 +199,7 @@ public class ClassDescriptor {
             source.children.remove( this );
         }
         parents.clear();
-        // eigentlich auch füŸr die outgoings, aber wir werden nur aufgerufen, wenn die outgoings schon leer sind
+        // also for outgoings, but we are only called when the outgoings are emptied already
         removeDescriptor( this.key );
     }
 

--- a/org.projectusus.core/test/org/projectusus/core/testutil/PrimitiveAssert.java
+++ b/org.projectusus.core/test/org/projectusus/core/testutil/PrimitiveAssert.java
@@ -4,8 +4,8 @@ import org.hamcrest.Matcher;
 import org.junit.Assert;
 
 /**
- * Hilfsklasse, um assertThat-Aufrufe auch mit Primitivtypen und ohne Auto-(Un-)Boxing zu ermöglichen.
- * 
+ * Utility class to allow calling <code>assertThat</code> on primitive types and without auto boxing/unboxing.
+ *
  */
 public class PrimitiveAssert {
 

--- a/org.projectusus.core/test/org/projectusus/core/testutil/PrimitiveMatchers.java
+++ b/org.projectusus.core/test/org/projectusus/core/testutil/PrimitiveMatchers.java
@@ -4,9 +4,9 @@ import org.hamcrest.Matcher;
 import org.hamcrest.Matchers;
 
 /**
- * Hilfsklasse, um assertThat-Aufrufe auch mit Primitivtypen und ohne Auto-(Un-)Boxing zu ermöglichen.
- * 
- * 
+ * Utility class to allow calling <code>is</code> on primitive types and without auto boxing/unboxing.
+ *
+ *
  */
 public class PrimitiveMatchers {
 


### PR DESCRIPTION
On Ubuntu those files are rendered quite ugly (even though the Windows
character encoding is used correctly). Therefore I replaced those
occurrences of umlauts using English comments.
