### PR TITLE
show refactoring menu on graph nodes

### DIFF
--- a/org.projectusus.ui.dependencygraph/src/org/projectusus/ui/dependencygraph/nodes/ClassRepresenter.java
+++ b/org.projectusus.ui.dependencygraph/src/org/projectusus/ui/dependencygraph/nodes/ClassRepresenter.java
@@ -6,7 +6,9 @@ import java.util.List;
 import java.util.Set;
 
 import org.eclipse.core.resources.IFile;
+import org.eclipse.core.runtime.IAdaptable;
 import org.eclipse.jdt.core.IJavaElement;
+import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.ui.ISharedImages;
 import org.projectusus.core.filerelations.model.ClassDescriptor;
 import org.projectusus.core.filerelations.model.Packagename;
@@ -17,7 +19,7 @@ import ch.akuhn.foreach.ForEach;
 import com.google.common.base.Function;
 import com.google.common.collect.Collections2;
 
-public class ClassRepresenter implements GraphNode {
+public class ClassRepresenter implements GraphNode, IAdaptable {
 
     private final ClassDescriptor clazz;
 
@@ -171,5 +173,12 @@ public class ClassRepresenter implements GraphNode {
 
     public boolean represents( IJavaElement javaElement ) {
         return javaElement.getResource().equals( getFile() );
+    }
+
+    public Object getAdapter( @SuppressWarnings( "rawtypes" ) Class adapter ) {
+        if( adapter.equals( IJavaElement.class ) ) {
+            return JavaCore.create( getFile() );
+        }
+        return null;
     }
 }

--- a/org.projectusus.ui.dependencygraph/src/org/projectusus/ui/dependencygraph/nodes/PackageRepresenter.java
+++ b/org.projectusus.ui.dependencygraph/src/org/projectusus/ui/dependencygraph/nodes/PackageRepresenter.java
@@ -5,6 +5,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 import org.eclipse.core.resources.IFile;
+import org.eclipse.core.runtime.IAdaptable;
 import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.ui.ISharedImages;
 import org.eclipse.jdt.ui.JavaElementLabels;
@@ -14,7 +15,7 @@ import org.projectusus.core.filerelations.model.Packagename;
 import com.google.common.base.Function;
 import com.google.common.collect.Collections2;
 
-public class PackageRepresenter implements GraphNode {
+public class PackageRepresenter implements GraphNode, IAdaptable {
 
     private final Packagename packagename;
     private static PackageRelations relations;
@@ -117,6 +118,13 @@ public class PackageRepresenter implements GraphNode {
     public boolean represents( IJavaElement javaElement ) {
         IJavaElement pkg = javaElement.getAncestor( IJavaElement.PACKAGE_FRAGMENT );
         return pkg != null && getRelatedPackage().getJavaElement().getElementName().equals( pkg.getElementName() );
+    }
+
+    public Object getAdapter( @SuppressWarnings( "rawtypes" ) Class adapter ) {
+        if( adapter.equals( IJavaElement.class ) ) {
+            return getPackagename().getJavaElement();
+        }
+        return null;
     }
 
 }


### PR DESCRIPTION
The JDT refactoring menu is added to the graph node context menu, and
the graph or package nodes are adapted to Java elements to actually
enable the refactoring actions.

There is a small, but acceptable issue: The refactoring menu shows its
normal keyboard shortcuts, which don't work in the graph view.
