### PR TITLE
avoid confusing context names in keys preference dialog

### DIFF
--- a/org.projectusus.ui.dependencygraph/plugin.xml
+++ b/org.projectusus.ui.dependencygraph/plugin.xml
@@ -466,11 +466,11 @@
          point="org.eclipse.ui.contexts">
       <context
             id="org.projectusus.ui.dependencygraph.ClassGraphView.context.customFilter"
-            name="org.projectusus.ui.dependencygraph.ClassGraphView.context.customFilter">
+            name="Filtered class graph">
       </context>
       <context
             id="org.projectusus.ui.dependencygraph.PackageGraphView.context.customFilter"
-            name="org.projectusus.ui.dependencygraph.PackageGraphView.context.customFilter">
+            name="Filtered package graph">
       </context>
    </extension>
    


### PR DESCRIPTION
In the key binding preferences, Usus lists 2 contexts with an ID instead of a name.
