### PR TITLE
Please merge two small fixes

### DIFF
--- a/org.projectusus.core/test/org/projectusus/core/filerelations/model/test/CrossPackageClassRelationsTest.java
+++ b/org.projectusus.core/test/org/projectusus/core/filerelations/model/test/CrossPackageClassRelationsTest.java
@@ -49,8 +49,12 @@ public class CrossPackageClassRelationsTest {
         ClassDescriptor descriptor1 = createClassDescriptor( "Descriptor4" );
         ClassDescriptor descriptor2 = createClassDescriptor( "Descriptor5" );
         descriptor1.addChild( descriptor2 );
+        Set<ClassDescriptor> descriptors = ClassDescriptor.getAll();
 
-        checkTwoNodesWithOneChildEach( ClassDescriptor.getAll() );
+        assertEquals( 2, descriptors.size() );
+        assertEquals( 1, descriptor1.getChildren().size() );
+        assertEquals( 0, descriptor2.getChildren().size() );
+
         assertEquals( 1, new CrossPackageClassRelations().getAllDirectRelations().size() );
     }
 

--- a/org.projectusus.ui.dependencygraph/src/org/projectusus/ui/dependencygraph/sourcefolder/SourceFolderFilterExtension.java
+++ b/org.projectusus.ui.dependencygraph/src/org/projectusus/ui/dependencygraph/sourcefolder/SourceFolderFilterExtension.java
@@ -12,6 +12,7 @@ import java.util.Set;
 
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.jdt.core.ElementChangedEvent;
 import org.eclipse.jdt.core.IElementChangedListener;
@@ -97,8 +98,19 @@ public class SourceFolderFilterExtension {
     private IJavaProject[] convertToJavaProjects( List<IProject> ususProjects ) {
         List<IJavaProject> result = new LinkedList<IJavaProject>();
         for( IProject project : ususProjects ) {
-            result.add( JavaCore.create( project ) );
+            if( canScanProject( project ) ) {
+                IJavaProject javaProject = JavaCore.create( project );
+                result.add( javaProject );
+            }
         }
         return result.toArray( new IJavaProject[result.size()] );
+    }
+
+    private boolean canScanProject( IProject project ) {
+        try {
+            return project.isOpen() && project.getProject().hasNature( JavaCore.NATURE_ID );
+        } catch( CoreException e ) {
+            return false;
+        }
     }
 }


### PR DESCRIPTION
I found that the 0.7.7 feature "visible source folders" produced a Java Model Exception when scanning for package fragments in projects without a Java nature. The fix was simple.
Also, I fixed a unit test when getting familiar with the Relations class.